### PR TITLE
issue-172: Dialog Class update usage example & `show()` return type

### DIFF
--- a/src/window/dialog.ts
+++ b/src/window/dialog.ts
@@ -36,9 +36,10 @@ let dialogProxy: any;
  *      .setTitle('ThisDialogReturnsAString')
  *      .setBorderOptions(true, false)
  *      .setButtons(true, true)
- *      .show()
- *      .getResult().then(function(result) {
- *        document.getElementById('input').value = result;
+ *      .show().then(function(dialog) {
+ *        .getResult().then(function(result) {
+ *          document.getElementById('input').value = result;
+ *        });
  *      });
  *    });
  *  });
@@ -140,7 +141,7 @@ export class Dialog{
    *  external.Close();
    *  ```
    */
-  static return(result ?: string):Promise<any> {
+  static return(result ?: string): Promise<any> {
     return new Promise(resolve => {
       if (result !== undefined) {
         exec('SetDialogResult', result).then(res => {
@@ -226,7 +227,7 @@ export class Dialog{
   }
 
   /**
-   *  return: Dialog
+   *  return: Promise<Dialog>
    *
    *  After configuring the dialog, call this function to spawn it.
    *


### PR DESCRIPTION
Updated the usage example to show that `.getResult()` should be part of a promise chain. Also update the return type of the `show()` method to correctly indicate that it returns an instance of `Promise<Dialog>`.