### PR TITLE
Added property `types` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "karma start --single-run --browsers Chrome"
   },
   "main": "src/index.ts",
+  "types": "src/index.ts",
   "devDependencies": {
     "bower": "^1.4.1",
     "browser-sync": "2.18.2",


### PR DESCRIPTION
VSCode Intellisense couldn't find the module definition because the NPM package didn't have a [property "types"](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) that points to index.ts
  